### PR TITLE
Removing min-master version for gke-standard

### DIFF
--- a/terraform/modules/gke-standard/main.tf
+++ b/terraform/modules/gke-standard/main.tf
@@ -32,13 +32,6 @@ resource "random_shuffle" "zone" {
   result_count = 3
 }
 
-data "google_container_engine_versions" "central1b" {
-  provider       = google-beta
-  location       = var.region
-  version_prefix = var.min_master_version
-  project        = var.project_id
-}
-
 resource "google_container_cluster" "risk-research" {
   deletion_protection = false
   provider            = google-beta
@@ -48,7 +41,6 @@ resource "google_container_cluster" "risk-research" {
   datapath_provider   = var.datapath_provider
   node_locations      = [random_shuffle.zone.result[0], random_shuffle.zone.result[1], random_shuffle.zone.result[2]]
   depends_on          = [google_kms_crypto_key_iam_member.gke_crypto_key]
-  min_master_version  = data.google_container_engine_versions.central1b.latest_master_version
 
   # We do this to ensure we have large control plane nodes created initially
   initial_node_count       = var.scaled_control_plane ? 700 : 1


### PR DESCRIPTION
Let GKE will automatically select the appropriate master version for the specified release channel. 