### PR TITLE
Adding random suffix to log bucket

### DIFF
--- a/examples/risk/loadtest/main.tf
+++ b/examples/risk/loadtest/main.tf
@@ -91,6 +91,14 @@ locals {
   })
 }
 
+resource "random_string" "bucket_suffix" {
+  length  = 5
+  special = false
+  upper   = false
+  lower   = true
+  numeric = true
+}
+
 data "google_project" "environment" {
   project_id = var.project_id
 }
@@ -246,7 +254,7 @@ resource "google_logging_project_bucket_config" "analytics-enabled-bucket" {
   project          = var.project_id
   location         = module.default_region.default_region
   enable_analytics = true
-  bucket_id        = "applogs"
+  bucket_id        = "applogs-${random_string.bucket_suffix.result}"
   lifecycle {
     ignore_changes = [project]
   }

--- a/examples/risk/loadtest/versions.tf
+++ b/examples/risk/loadtest/versions.tf
@@ -22,6 +22,10 @@ terraform {
       source  = "hashicorp/google-beta"
       version = ">= 6.29.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
   }
   provider_meta "google" {
     module_name = "cloud-solutions/fsi-rdp-loadtest-v1.0.0"


### PR DESCRIPTION
Adding a random suffix to log_bucket name in the loadtest example to ensure there is no naming collisions if redeploying the solution. 